### PR TITLE
conference.hpp: include <memory> to use std::unique_ptr

### DIFF
--- a/src/conference.hpp
+++ b/src/conference.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <functional>
+#include <memory>
 
 #include "codec-type.hpp"
 #include "jingle/jingle.hpp"


### PR DESCRIPTION
compile error message
```log
../src/jitsi/conference.hpp: At global scope:
../src/jitsi/conference.hpp:80:79: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
   80 |     static auto create(Config config, ConferenceCallbacks* callbacks) -> std::unique_ptr<Conference>;
      |                                                                               ^~~~~~~~~~
```